### PR TITLE
Bump Swift Argument Parser from 1.0.1 to 1.1.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
-        "version" : "1.0.1"
+        "revision" : "df9ee6676cd5b3bf5b330ec7568a5644f547201b",
+        "version" : "1.1.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .executable(name: "uhooi", targets: ["OutputUhooi"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/OutputUhooi/Uhooi.swift
+++ b/Sources/OutputUhooi/Uhooi.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import OutputUhooiCore
 
 @main
-struct Uhooi: ParsableCommand {
+struct Uhooi: AsyncParsableCommand {
     
     static var configuration = CommandConfiguration(
         abstract: "Uhooi speak the phrase.",
@@ -18,7 +18,7 @@ struct Uhooi: ParsableCommand {
     @Argument(help: "The phrase to repeat.")
     var phrase: String
     
-    mutating func run() throws {
+    mutating func run() async throws {
         print(TextBuilder.buildText(phrase: phrase, count: count, includeCounter: includeCounter))
     }
 }

--- a/Sources/OutputUhooiCore/TextBuilder.swift
+++ b/Sources/OutputUhooiCore/TextBuilder.swift
@@ -1,4 +1,4 @@
-final public class TextBuilder {
+public enum TextBuilder {
     public static func buildText(phrase: String, count: Int?, includeCounter: Bool) -> String {
         let repeatCount = count ?? 1
         guard repeatCount >= 1 else {


### PR DESCRIPTION
## References

- https://github.com/apple/swift-argument-parser/pull/404
- https://github.com/apple/swift-argument-parser/blob/df9ee6676cd5b3bf5b330ec7568a5644f547201b/Examples/count-lines/CountLines.swift